### PR TITLE
chore: configure Vite base for GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  base: "/github-issue-manager/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set Vite base to `/github-issue-manager/` so built assets resolve correctly

## Testing
- `npm ci` *(fails: 403 Forbidden - victory-vendor)*
- `npm install` *(fails: 403 Forbidden - victory-vendor)*

------
https://chatgpt.com/codex/tasks/task_e_689c5599a0488328bd94736df175b0d4