### PR TITLE
feat: add legend and colors to dashboard chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ import { Badge } from "./components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "./components/ui/avatar";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./components/ui/table";
 import { Loader2, Github, RefreshCcw, Search, ShieldQuestion, ExternalLink, FolderKanban } from "lucide-react";
-import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid } from "recharts";
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from "recharts";
 
 /**
  * GitHub Issues Manager (React)
@@ -309,8 +309,9 @@ export default function App() {
                         <XAxis dataKey="date" hide />
                         <YAxis allowDecimals={false} />
                         <Tooltip />
-                        <Line type="monotone" dataKey="opened" />
-                        <Line type="monotone" dataKey="closed" />
+                        <Legend />
+                        <Line type="monotone" dataKey="opened" name="Opened" stroke="#22c55e" />
+                        <Line type="monotone" dataKey="closed" name="Closed" stroke="#ef4444" />
                       </LineChart>
                     </ResponsiveContainer>
                   </div>

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react'
 import path from 'path'
 
 export default defineConfig({
+  base: "/github-issue-manager/",
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- set Vite base to `/github-issue-manager/` so built assets resolve correctly
- add legend and distinct colors for opened and closed lines in the dashboard chart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_689c5599a0488328bd94736df175b0d4