### PR TITLE
Add sprint burn chart and improve issue cards

### DIFF
--- a/src/components/ui/avatar.jsx
+++ b/src/components/ui/avatar.jsx
@@ -1,6 +1,13 @@
 import React from "react";
-export function Avatar({ className="", children }) {
-  return <div className={`rounded-full overflow-hidden bg-gray-200 ${className}`}>{children}</div>;
+export function Avatar({ className="", children, ...props }) {
+  return (
+    <div
+      className={`rounded-full overflow-hidden bg-gray-200 ${className}`}
+      {...props}
+    >
+      {children}
+    </div>
+  );
 }
 export function AvatarImage({ src, alt="" }) {
   return <img src={src} alt={alt} className="w-full h-full object-cover" />;


### PR DESCRIPTION
## Summary
- add sprint burn chart with week/month/year filters on dashboard
- show milestone only where needed and support tooltip on assignee avatars
- fetch and display issue type labels with color and include closed counts in burn chart

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f2416f4ac832895f3462f83b4f05e