### PR TITLE
feat: add issue type filtering and display

### DIFF
--- a/src/components/AllIssues.jsx
+++ b/src/components/AllIssues.jsx
@@ -41,12 +41,15 @@ export default function AllIssues({
   setFilterProjectStatus,
   filterAssignee,
   setFilterAssignee,
+  filterIssueType,
+  setFilterIssueType,
   filterTag,
   setFilterTag,
   filterMilestone,
   setFilterMilestone,
   projectStatusOptions,
   assigneeOptions,
+  issueTypeOptions,
   tagOptions,
   milestoneOptions
 }) {
@@ -59,6 +62,7 @@ export default function AllIssues({
         (filterAssignee === "(unassigned)"
           ? i.assignees.length === 0
           : i.assignees.some(a => a.login === filterAssignee))) &&
+      (!filterIssueType || i.issueType?.name === filterIssueType) &&
       (!filterTag || i.labels.some(l => l.name === filterTag)) &&
       (!filterMilestone ||
         (filterMilestone === "(none)"
@@ -71,7 +75,7 @@ export default function AllIssues({
         i.labels.some(l => l.name.toLowerCase().includes(q))
       )
     );
-  }, [allIssuesWithStatus, filterState, filterProjectStatus, filterAssignee, filterTag, filterMilestone, query]);
+  }, [allIssuesWithStatus, filterState, filterProjectStatus, filterAssignee, filterIssueType, filterTag, filterMilestone, query]);
 
   return (
     <div className="space-y-6">
@@ -92,6 +96,10 @@ export default function AllIssues({
         <select value={filterAssignee} onChange={e=>setFilterAssignee(e.target.value)} className="border rounded-md text-sm px-2 py-1">
           <option value="">All Assignees</option>
           {assigneeOptions.map(a => <option key={a} value={a}>{a}</option>)}
+        </select>
+        <select value={filterIssueType} onChange={e=>setFilterIssueType(e.target.value)} className="border rounded-md text-sm px-2 py-1">
+          <option value="">All Types</option>
+          {issueTypeOptions.map(t => <option key={t} value={t}>{t}</option>)}
         </select>
         <select value={filterTag} onChange={e=>setFilterTag(e.target.value)} className="border rounded-md text-sm px-2 py-1">
           <option value="">All Tags</option>

--- a/src/components/IssueCard.jsx
+++ b/src/components/IssueCard.jsx
@@ -19,8 +19,7 @@ function getContrastColor(hexColor) {
 }
 
 export default function IssueCard({ issue, showMilestone = true }) {
-  const typeLabel = issue.labels.find(l => /^type:\s*/i.test(l.name));
-  const otherLabels = issue.labels.filter(l => l !== typeLabel);
+  const otherLabels = issue.labels.filter(l => !/^type:\s*/i.test(l.name));
   
   return (
     <Card>
@@ -42,13 +41,16 @@ export default function IssueCard({ issue, showMilestone = true }) {
         {issue.project_status && (
           <div className="text-xs text-gray-500 mb-1">Status: {issue.project_status}</div>
         )}
-        {typeLabel && (
+        {issue.issueType && (
           <div className="mt-1">
             <span
               className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium"
-              style={{ backgroundColor: `#${typeLabel.color}`, color: getContrastColor(typeLabel.color) }}
+              style={{
+                backgroundColor: `#${(issue.issueType.color || "").replace(/^#/, "")}`,
+                color: getContrastColor((issue.issueType.color || "").replace(/^#/, "")),
+              }}
             >
-              {typeLabel.name.replace(/^Type:\s*/i, "")}
+              {issue.issueType.name}
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- fetch organization issue types and include issue type in GraphQL queries
- add issue type filter on All Issues page
- display issue type as colored pill on issue cards

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module @rollup/rollup-linux-x64-gnu)


------
https://chatgpt.com/codex/tasks/task_e_689f4835dec48328ac1b32f80fe52780