### PR TITLE
fix routing base path for GitHub pages

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/github-issue-manager">
       <App />
     </BrowserRouter>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- configure React Router with basename for GitHub Pages so navigation keeps repository path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7f716ab348328bc78726d79caa75b