### PR TITLE
feat: export sprint release notes as PDF

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.8.0",
-    "recharts": "^2.15.4"
+    "recharts": "^2.15.4",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.7.0",

--- a/src/components/Sprints.jsx
+++ b/src/components/Sprints.jsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from "react";
 import { Card, CardHeader, CardContent, CardTitle } from "./ui/card";
 import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
 import IssueCard from "./IssueCard";
+import jsPDF from "jspdf";
 
 function fmtDate(iso) {
   const d = new Date(iso);
@@ -33,6 +35,87 @@ export default function Sprints({ allIssues }) {
     }));
   }, [allIssues]);
 
+  async function summarizeIssues(issues) {
+    const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+    if (!apiKey) return "";
+    try {
+      const res = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-4o-mini",
+          messages: [
+            { role: "system", content: "You are a helpful release notes generator." },
+            {
+              role: "user",
+              content: `Summarize the following issues in one short paragraph:\n${issues
+                .map(i => `- ${i.title}`)
+                .join("\n")}`,
+            },
+          ],
+          max_tokens: 120,
+          temperature: 0.2,
+        }),
+      });
+      const data = await res.json();
+      return data.choices?.[0]?.message?.content?.trim() || "";
+    } catch (err) {
+      console.error("LLM summary failed", err);
+      return "";
+    }
+  }
+
+  function splitIssues(issues) {
+    const isFeature = i =>
+      /feature|enhancement/i.test(i.issueType?.name || "") ||
+      i.labels.some(l => /^type:\s*(feature|enhancement)/i.test(l.name));
+    const isBug = i =>
+      /bug/i.test(i.issueType?.name || "") ||
+      i.labels.some(l => /^type:\s*bug/i.test(l.name));
+    return {
+      features: issues.filter(isFeature),
+      bugs: issues.filter(isBug),
+    };
+  }
+
+  async function downloadReleaseNotes(sp) {
+    const { features, bugs } = splitIssues(sp.issues);
+    const summary = await summarizeIssues(sp.issues);
+
+    const doc = new jsPDF();
+    let y = 10;
+    doc.text(`Release Notes - ${sp.title}`, 10, y);
+    y += 10;
+    if (summary) {
+      const lines = doc.splitTextToSize(summary, 180);
+      doc.text(lines, 10, y);
+      y += lines.length * 7 + 3;
+    }
+    if (features.length) {
+      doc.text("Features:", 10, y);
+      y += 7;
+      features.forEach(f => {
+        const lines = doc.splitTextToSize(`#${f.number} ${f.title}`, 180);
+        doc.text(lines, 10, y);
+        y += lines.length * 7;
+      });
+      y += 3;
+    }
+    if (bugs.length) {
+      doc.text("Bugs:", 10, y);
+      y += 7;
+      bugs.forEach(b => {
+        const lines = doc.splitTextToSize(`#${b.number} ${b.title}`, 180);
+        doc.text(lines, 10, y);
+        y += lines.length * 7;
+      });
+    }
+    doc.save(`${sp.title}-release-notes.pdf`);
+  }
+
   return (
     <div className="space-y-6">
       <div className="grid md:grid-cols-2 gap-4">
@@ -40,16 +123,29 @@ export default function Sprints({ allIssues }) {
           <Card key={sp.id}>
             <CardHeader>
               <div className="flex items-center justify-between">
-                <CardTitle className="truncate">
-                  <a href={sp.url} target="_blank" rel="noreferrer" className="hover:underline">{sp.title}</a>
-                </CardTitle>
+                <div className="flex items-center gap-2">
+                  <CardTitle className="truncate">
+                    <a href={sp.url} target="_blank" rel="noreferrer" className="hover:underline">
+                      {sp.title}
+                    </a>
+                  </CardTitle>
+                  <Button
+                    className="text-xs border px-2 py-1"
+                    onClick={() => downloadReleaseNotes(sp)}
+                  >
+                    Download
+                  </Button>
+                </div>
                 <Badge variant="secondary">{sp.closed}/{sp.open + sp.closed}</Badge>
               </div>
               {sp.dueOn && <div className="text-xs text-gray-500 mt-1">Due {fmtDate(sp.dueOn)}</div>}
             </CardHeader>
             <CardContent>
               <div className="w-full bg-gray-100 rounded-full h-2 mb-3">
-                <div className="bg-blue-500 h-2 rounded-full" style={{ width: `${((sp.closed/(sp.open+sp.closed))*100 || 0)}%` }} />
+                <div
+                  className="bg-blue-500 h-2 rounded-full"
+                  style={{ width: `${((sp.closed / (sp.open + sp.closed)) * 100 || 0)}%` }}
+                />
               </div>
               <div className="space-y-2 max-h-60 overflow-auto pr-1">
                 {sp.issues.map(iss => (
@@ -59,7 +155,13 @@ export default function Sprints({ allIssues }) {
             </CardContent>
           </Card>
         ))}
-        {!sprints.length && <Card><CardContent className="py-10"><div className="text-sm text-gray-500">No data available.</div></CardContent></Card>}
+        {!sprints.length && (
+          <Card>
+            <CardContent className="py-10">
+              <div className="text-sm text-gray-500">No data available.</div>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add sprint-level release notes PDF download with features/bugs grouping
- generate one-paragraph release summary using LLM
- include jspdf for PDF generation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import "jspdf")*


------
https://chatgpt.com/codex/tasks/task_e_68a9a5b9d22c83288541da6df27f4a98