### PR TITLE
Add CSP meta tag to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; img-src 'self' https://avatars.githubusercontent.com; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self' https://api.github.com"
+    />
     <title>GitHub Issues Manager</title>
     <script>
       // Prevent flash of unstyled content


### PR DESCRIPTION
## Summary
- add Content Security Policy meta tag tailored for GitHub avatars and API calls

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1ec112483289e66ecea8d885a67