### PR TITLE
Disable autocomplete for token input

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -458,7 +458,7 @@ export default function App() {
             </a>
             <div className="ml-auto flex items-center gap-2 w-full sm:w-auto">
               <Input placeholder="Organization (e.g. vercel)" value={org} onChange={e=>setOrg(e.target.value)} className="w-44" />
-              <Input placeholder="Personal Access Token" type="password" value={token} onChange={e=>setToken(e.target.value)} className="w-64" />
+              <Input placeholder="Personal Access Token" type="password" autoComplete="off" value={token} onChange={e=>setToken(e.target.value)} className="w-64" />
               <Button className="bg-black text-white" onClick={loadData} disabled={loading || !org || !token}>
                 {loading ? (<><Loader2 className="w-4 h-4 animate-spin"/><span>Loading</span></>) : (<><RefreshCcw className="w-4 h-4"/><span>Load</span></>)}
               </Button>


### PR DESCRIPTION
## Summary
- disable autocomplete on Personal Access Token input field

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1e87a588328b421133379ee020e