### PR TITLE
chore: guard sprint debug logs

### DIFF
--- a/src/components/Sprints.jsx
+++ b/src/components/Sprints.jsx
@@ -70,12 +70,14 @@ function splitIssues(issues) {
   };
 
   // Debug: Log categorization results
-  console.log('Issue Categorization Debug:');
-  issues.forEach(issue => {
-    const feature = isFeature(issue);
-    const bug = isBug(issue);
-    console.log(`#${issue.number}: "${issue.title}" - Feature: ${feature}, Bug: ${bug}, Labels: [${issue.labels.map(l => l.name).join(', ')}]`);
-  });
+  if (import.meta.env.DEV) {
+    console.log('Issue Categorization Debug:');
+    issues.forEach(issue => {
+      const feature = isFeature(issue);
+      const bug = isBug(issue);
+      console.log(`#${issue.number}: "${issue.title}" - Feature: ${feature}, Bug: ${bug}, Labels: [${issue.labels.map(l => l.name).join(', ')}]`);
+    });
+  }
 
   return {
     features: issues.filter(isFeature),


### PR DESCRIPTION
## Summary
- wrap sprint issue categorization debug logs in development guard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1e9d4f083288c2bd06ead9ea57f