### PR TITLE
fix: encode org for issue type fetch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -193,7 +193,7 @@ async function fetchProjectsWithStatus(token, org) {
 }
 
 async function fetchIssueTypes(token, org) {
-  const res = await fetch(`https://api.github.com/orgs/${org}/issue-types`, {
+  const res = await fetch(`https://api.github.com/orgs/${encodeURIComponent(org)}/issue-types`, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",


### PR DESCRIPTION
## Summary
- encode org in issue type fetch request

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1e7322483289f87d556e711f8fa