### PR TITLE
fix: ensure safe external links

### DIFF
--- a/src/components/ByAssignee.jsx
+++ b/src/components/ByAssignee.jsx
@@ -85,7 +85,7 @@ export default function ByAssignee({
                           <AvatarImage src={row.assignee.avatarUrl} />
                           <AvatarFallback>{initials(row.assignee.login)}</AvatarFallback>
                         </Avatar>
-                        <a href={row.assignee.url} target="_blank" rel="noreferrer" className="hover:underline">
+                        <a href={row.assignee.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
                           {row.assignee.login}
                         </a>
                       </div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -299,7 +299,7 @@ export default function Dashboard({
     <div className="space-y-6">
       <div className="flex flex-wrap items-center gap-3">
         {orgMeta && (
-          <a href={orgMeta.url} target="_blank" rel="noreferrer" className="text-sm text-blue-600 inline-flex items-center gap-1">
+          <a href={orgMeta.url} target="_blank" rel="noopener noreferrer" className="text-sm text-blue-600 inline-flex items-center gap-1">
             {orgMeta.name} <ExternalLink className="w-3 h-3"/>
           </a>
         )}
@@ -463,7 +463,7 @@ export default function Dashboard({
               {latest5.map(iss => (
                 <li key={iss.id} className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <a href={iss.url} target="_blank" rel="noreferrer" className="font-medium hover:underline truncate block">#{iss.number} {iss.title}</a>
+                    <a href={iss.url} target="_blank" rel="noopener noreferrer" className="font-medium hover:underline truncate block">#{iss.number} {iss.title}</a>
                       <div className="text-xs text-gray-500">{iss.repository?.nameWithOwner} • <TimeAgo iso={iss.createdAt} /></div>
                     <div className="mt-1 flex flex-wrap gap-1">
                       {iss.labels.map(l => (
@@ -501,7 +501,7 @@ export default function Dashboard({
                       <AvatarImage src={row.assignee.avatarUrl} />
                       <AvatarFallback>{initials(row.assignee.login)}</AvatarFallback>
                     </Avatar>
-                    <a href={row.assignee.url} target="_blank" rel="noreferrer" className="text-sm hover:underline">
+                    <a href={row.assignee.url} target="_blank" rel="noopener noreferrer" className="text-sm hover:underline">
                       {row.assignee.login}
                     </a>
                   </div>

--- a/src/components/IssueCard.jsx
+++ b/src/components/IssueCard.jsx
@@ -33,7 +33,7 @@ export default function IssueCard({ issue, showMilestone = true }) {
       <CardHeader>
         <div className="flex items-center justify-between">
           <CardTitle className="truncate">
-            <a href={issue.url} target="_blank" rel="noreferrer" className="hover:underline">
+            <a href={issue.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
               #{issue.number} {issue.title}
             </a>
           </CardTitle>

--- a/src/components/ProjectBoard.jsx
+++ b/src/components/ProjectBoard.jsx
@@ -112,7 +112,7 @@ export default function ProjectBoard({ projects }) {
                 <ul className="space-y-3 max-h-[70vh] overflow-auto pr-1" onDragOver={e=>e.preventDefault()} onDrop={e=>{e.preventDefault(); const data = JSON.parse(e.dataTransfer.getData('text/plain')); handleDrop(data.issueId, status);}}>
                   {filteredList.map(iss => (
                     <li key={iss.id} className="p-3 border rounded-xl bg-white shadow-sm" draggable onDragStart={e=>e.dataTransfer.setData('text/plain', JSON.stringify({ issueId: iss.id }))}>
-                      <a href={iss.url} target="_blank" rel="noreferrer" className="font-medium hover:underline block">#{iss.number} {iss.title}</a>
+                      <a href={iss.url} target="_blank" rel="noopener noreferrer" className="font-medium hover:underline block">#{iss.number} {iss.title}</a>
                         <div className="text-xs text-gray-500">{iss.repository} • <TimeAgo iso={iss.createdAt} /></div>
                     </li>
                   ))}

--- a/src/components/Sprints.jsx
+++ b/src/components/Sprints.jsx
@@ -448,7 +448,7 @@ export default function Sprints({ allIssues, orgMeta }) {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <CardTitle className="truncate">
-                    <a href={sp.url} target="_blank" rel="noreferrer" className="hover:underline">
+                    <a href={sp.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
                       {sp.title}
                     </a>
                   </CardTitle>


### PR DESCRIPTION
## Summary
- prevent reverse tabnabbing by using `rel="noopener noreferrer"` on all `target="_blank"` links
- update Dashboard, IssueCard, ByAssignee, ProjectBoard, and Sprints components

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f1e5f7a88328ab98b7d796b90952