### PR TITLE
feat: add expandable sprint kanban view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -548,9 +548,10 @@ export default function App() {
               />
             } />
             <Route path="/sprints" element={
-              <Sprints 
+              <Sprints
                 allIssues={allIssues}
                 orgMeta={orgMeta}
+                projects={projects}
               />
             } />
             <Route path="/all-issues" element={


### PR DESCRIPTION
## Summary
- show sprints collapsible with current sprint expanded by default
- group sprint issues into kanban columns based on Syneca Road map status

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0dfc2be08328b3b400fcd0adba9b