### PR TITLE
feat: add context-based state management

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { Button } from "./components/ui/button";
 import { Input } from "./components/ui/input";
 import { Loader2, Github, RefreshCcw, ShieldQuestion, Sun, Moon, Monitor, Maximize2, Minimize2, ExternalLink } from "lucide-react";
 import { githubGraphQL, ORG_REPOS_ISSUES, fetchProjectsWithStatus, fetchIssueTypes } from "./api/github";
+import useAppStore from "./store";
 
 // Import components
 const Navigation = lazy(() => import("./components/Navigation"));
@@ -43,31 +44,32 @@ export default function App() {
   const [projects, setProjects] = useState([]);
   const [issueTypes, setIssueTypes] = useState([]);
 
-  // Chart state
-  const [range, setRange] = useState("month"); // week | month | year
-  const [burnRange, setBurnRange] = useState("month"); // for burn chart
-
-  // Search and filters
-  const [query, setQuery] = useState("");
-  const [filterState, setFilterState] = useState("");
-  const [filterProjectStatus, setFilterProjectStatus] = useState("");
-  const [filterAssignee, setFilterAssignee] = useState("");
-  const [filterTag, setFilterTag] = useState("");
-  const [filterMilestone, setFilterMilestone] = useState("");
-  const [filterIssueType, setFilterIssueType] = useState("");
-
-  // Default theme is light mode - force reset if needed
-  const [theme, setTheme] = useState(() => {
-    const storedTheme = localStorage.getItem("theme");
-    // If no theme is stored or if it's auto (which might default to dark), use light
-    if (!storedTheme || storedTheme === "auto") {
-      localStorage.setItem("theme", "light");
-      return "light";
-    }
-    return storedTheme;
-  });
-  const [density, setDensity] = useState(() => localStorage.getItem("density") || "comfy");
-  const [sidebarOpen, setSidebarOpen] = useState(true);
+  const {
+    query,
+    setQuery,
+    filterState,
+    setFilterState,
+    filterProjectStatus,
+    setFilterProjectStatus,
+    filterAssignee,
+    setFilterAssignee,
+    filterTag,
+    setFilterTag,
+    filterMilestone,
+    setFilterMilestone,
+    filterIssueType,
+    setFilterIssueType,
+    range,
+    setRange,
+    burnRange,
+    setBurnRange,
+    theme,
+    setTheme,
+    density,
+    setDensity,
+    sidebarOpen,
+    setSidebarOpen,
+  } = useAppStore();
 
   useEffect(() => {
     const root = document.documentElement;
@@ -81,14 +83,12 @@ export default function App() {
     } else {
       apply(theme === "dark");
     }
-    localStorage.setItem("theme", theme);
   }, [theme]);
 
   useEffect(() => {
     const root = document.documentElement;
     root.classList.remove("density-compact", "density-comfy");
     root.classList.add(density === "compact" ? "density-compact" : "density-comfy");
-    localStorage.setItem("density", density);
   }, [density]);
 
   useEffect(() => {
@@ -100,7 +100,7 @@ export default function App() {
       }
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
         e.preventDefault();
-        setSidebarOpen((s) => !s);
+        setSidebarOpen(!sidebarOpen);
       }
       if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "a") {
         e.preventDefault();
@@ -117,16 +117,15 @@ export default function App() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, []);
+  }, [sidebarOpen, setSidebarOpen]);
 
   const cycleTheme = () =>
-    setTheme((t) => (t === "light" ? "dark" : t === "dark" ? "auto" : "light"));
+    setTheme(theme === "light" ? "dark" : theme === "dark" ? "auto" : "light");
   const toggleDensity = () =>
-    setDensity((d) => (d === "comfy" ? "compact" : "comfy"));
+    setDensity(density === "comfy" ? "compact" : "comfy");
 
   // Temporary function to force reset theme to light mode
   const forceLightMode = () => {
-    localStorage.setItem("theme", "light");
     setTheme("light");
   };
 
@@ -330,45 +329,20 @@ export default function App() {
           <Suspense fallback={<div className="py-10 text-center"><Loader2 className="w-4 h-4 animate-spin"/></div>}>
           <Routes>
             <Route path="/" element={
-              <Dashboard 
+              <Dashboard
                 allIssues={allIssues}
                 allIssuesWithStatus={allIssuesWithStatus}
                 orgMeta={orgMeta}
-                query={query}
-                setQuery={setQuery}
-                range={range}
-                setRange={setRange}
-                burnRange={burnRange}
-                setBurnRange={setBurnRange}
-                setFilterAssignee={setFilterAssignee}
-                setFilterState={setFilterState}
-                setFilterProjectStatus={setFilterProjectStatus}
-                setFilterTag={setFilterTag}
-                setFilterIssueType={setFilterIssueType}
               />
             } />
             <Route path="/by-assignee" element={
               <ByAssignee
                 allIssues={allIssues}
-                query={query}
-                setQuery={setQuery}
-                setFilterAssignee={setFilterAssignee}
-                setFilterState={setFilterState}
-                setFilterProjectStatus={setFilterProjectStatus}
-                setFilterTag={setFilterTag}
-                setFilterIssueType={setFilterIssueType}
               />
             } />
             <Route path="/by-tags" element={
               <ByTags
                 allIssues={allIssues}
-                query={query}
-                setQuery={setQuery}
-                setFilterAssignee={setFilterAssignee}
-                setFilterState={setFilterState}
-                setFilterProjectStatus={setFilterProjectStatus}
-                setFilterTag={setFilterTag}
-                setFilterIssueType={setFilterIssueType}
               />
             } />
             <Route path="/project-board" element={
@@ -387,20 +361,6 @@ export default function App() {
             <Route path="/all-issues" element={
               <AllIssues
                 allIssuesWithStatus={allIssuesWithStatus}
-                query={query}
-                setQuery={setQuery}
-                filterState={filterState}
-                setFilterState={setFilterState}
-                filterProjectStatus={filterProjectStatus}
-                setFilterProjectStatus={setFilterProjectStatus}
-                filterAssignee={filterAssignee}
-                setFilterAssignee={setFilterAssignee}
-                filterTag={filterTag}
-                setFilterTag={setFilterTag}
-                filterMilestone={filterMilestone}
-                setFilterMilestone={setFilterMilestone}
-                filterIssueType={filterIssueType}
-                setFilterIssueType={setFilterIssueType}
                 projectStatusOptions={projectStatusOptions}
                 assigneeOptions={assigneeOptions}
                 tagOptions={tagOptions}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -2,11 +2,14 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';
+import { AppStoreProvider } from './store';
 
 test('shows instructions before data is loaded', () => {
   const html = renderToString(
     <MemoryRouter>
-      <App />
+      <AppStoreProvider>
+        <App />
+      </AppStoreProvider>
     </MemoryRouter>
   );
   expect(html).toContain('Enter your organization and token above, then click');

--- a/src/components/AllIssues.jsx
+++ b/src/components/AllIssues.jsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Download, Search } from "lucide-react";
 import IssueCard, { ExpandedIssueCard } from "./IssueCard";
+import useAppStore from "../store";
 
 function issuesToCSV(issues) {
   const headers = ["Number", "Title", "URL", "State", "Repository", "ProjectStatus", "CreatedAt", "ClosedAt"];
@@ -31,28 +32,30 @@ function downloadCSV(issues, filename) {
   URL.revokeObjectURL(url);
 }
 
-export default function AllIssues({ 
-  allIssuesWithStatus, 
-  query, 
-  setQuery,
-  filterState,
-  setFilterState,
-  filterProjectStatus,
-  setFilterProjectStatus,
-  filterAssignee,
-  setFilterAssignee,
-  filterIssueType,
-  setFilterIssueType,
-  filterTag,
-  setFilterTag,
-  filterMilestone,
-  setFilterMilestone,
+export default function AllIssues({
+  allIssuesWithStatus,
   projectStatusOptions,
   assigneeOptions,
   issueTypeOptions,
   tagOptions,
   milestoneOptions
 }) {
+  const {
+    query,
+    setQuery,
+    filterState,
+    setFilterState,
+    filterProjectStatus,
+    setFilterProjectStatus,
+    filterAssignee,
+    setFilterAssignee,
+    filterIssueType,
+    setFilterIssueType,
+    filterTag,
+    setFilterTag,
+    filterMilestone,
+    setFilterMilestone,
+  } = useAppStore();
   const PAGE_SIZE = 50;
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [clickedIssue, setClickedIssue] = useState(null);

--- a/src/components/ByAssignee.jsx
+++ b/src/components/ByAssignee.jsx
@@ -5,6 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Input } from "./ui/input";
 import { Search } from "lucide-react";
+import useAppStore from "../store";
 
 function initials(str = "?") {
   const parts = str.split(/\s+|\//g).filter(Boolean);
@@ -15,14 +16,16 @@ function initials(str = "?") {
 
 export default function ByAssignee({
   allIssues,
-  query,
-  setQuery,
-  setFilterAssignee,
-  setFilterState,
-  setFilterProjectStatus,
-  setFilterTag,
-  setFilterIssueType,
 }) {
+  const {
+    query,
+    setQuery,
+    setFilterAssignee,
+    setFilterState,
+    setFilterProjectStatus,
+    setFilterTag,
+    setFilterIssueType,
+  } = useAppStore();
   const byAssignee = useMemo(() => {
     const out = new Map();
     for (const iss of allIssues) {

--- a/src/components/ByTags.jsx
+++ b/src/components/ByTags.jsx
@@ -5,6 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from ".
 import { Badge } from "./ui/badge";
 import { Input } from "./ui/input";
 import { Search } from "lucide-react";
+import useAppStore from "../store";
 
 function getContrastColor(hex = "808080") {
   const r = parseInt(hex.substr(0, 2), 16);
@@ -16,14 +17,16 @@ function getContrastColor(hex = "808080") {
 
 export default function ByTags({
   allIssues,
-  query,
-  setQuery,
-  setFilterAssignee,
-  setFilterState,
-  setFilterProjectStatus,
-  setFilterTag,
-  setFilterIssueType,
 }) {
+  const {
+    query,
+    setQuery,
+    setFilterAssignee,
+    setFilterState,
+    setFilterProjectStatus,
+    setFilterTag,
+    setFilterIssueType,
+  } = useAppStore();
   const byLabel = useMemo(() => {
     const out = new Map();
     for (const iss of allIssues) {

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -4,24 +4,25 @@ import { Card, CardHeader, CardContent, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Badge } from "./ui/badge";
-  import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
-  import { ExternalLink, Search } from "lucide-react";
-  import {
-    ResponsiveContainer,
-    LineChart,
-    Line,
-    XAxis,
-    YAxis,
-    Tooltip,
-    Legend,
-    CartesianGrid,
-    PieChart,
-    Pie,
-    Cell,
-    BarChart,
-    Bar,
-  } from "recharts";
-  import TimeAgo from "./TimeAgo";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
+import { ExternalLink, Search } from "lucide-react";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+} from "recharts";
+import TimeAgo from "./TimeAgo";
+import useAppStore from "../store";
 
 // Helper functions
 function fmtDate(iso) {
@@ -69,18 +70,20 @@ export default function Dashboard({
   allIssues,
   allIssuesWithStatus,
   orgMeta,
-  query,
-  setQuery,
-  range,
-  setRange,
-  burnRange,
-  setBurnRange,
-  setFilterAssignee,
-  setFilterState,
-  setFilterProjectStatus,
-  setFilterTag,
-  setFilterIssueType,
 }) {
+  const {
+    query,
+    setQuery,
+    range,
+    setRange,
+    burnRange,
+    setBurnRange,
+    setFilterAssignee,
+    setFilterState,
+    setFilterProjectStatus,
+    setFilterTag,
+    setFilterIssueType,
+  } = useAppStore();
   const openedClosedSeries = useMemo(() => {
     if (range === "year") {
       const months = monthsRange(12);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import './index.css'
+import { AppStoreProvider } from './store'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter basename="/github-issue-manager">
-      <App />
-    </BrowserRouter>
+    <AppStoreProvider>
+      <BrowserRouter basename="/github-issue-manager">
+        <App />
+      </BrowserRouter>
+    </AppStoreProvider>
   </React.StrictMode>,
 )

--- a/src/store.jsx
+++ b/src/store.jsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useReducer } from "react";
+
+const getInitialTheme = () => {
+  if (typeof localStorage === "undefined") return "light";
+  const stored = localStorage.getItem("theme");
+  if (!stored || stored === "auto") {
+    localStorage.setItem("theme", "light");
+    return "light";
+  }
+  return stored;
+};
+
+const getInitialDensity = () => {
+  if (typeof localStorage === "undefined") return "comfy";
+  return localStorage.getItem("density") || "comfy";
+};
+
+const initialState = {
+  query: "",
+  filterState: "",
+  filterProjectStatus: "",
+  filterAssignee: "",
+  filterTag: "",
+  filterMilestone: "",
+  filterIssueType: "",
+  range: "month",
+  burnRange: "month",
+  theme: getInitialTheme(),
+  density: getInitialDensity(),
+  sidebarOpen: true,
+};
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "SET_QUERY":
+      return { ...state, query: action.payload };
+    case "SET_FILTER_STATE":
+      return { ...state, filterState: action.payload };
+    case "SET_FILTER_PROJECT_STATUS":
+      return { ...state, filterProjectStatus: action.payload };
+    case "SET_FILTER_ASSIGNEE":
+      return { ...state, filterAssignee: action.payload };
+    case "SET_FILTER_TAG":
+      return { ...state, filterTag: action.payload };
+    case "SET_FILTER_MILESTONE":
+      return { ...state, filterMilestone: action.payload };
+    case "SET_FILTER_ISSUE_TYPE":
+      return { ...state, filterIssueType: action.payload };
+    case "SET_RANGE":
+      return { ...state, range: action.payload };
+    case "SET_BURN_RANGE":
+      return { ...state, burnRange: action.payload };
+    case "SET_THEME":
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem("theme", action.payload);
+      }
+      return { ...state, theme: action.payload };
+    case "SET_DENSITY":
+      if (typeof localStorage !== "undefined") {
+        localStorage.setItem("density", action.payload);
+      }
+      return { ...state, density: action.payload };
+    case "SET_SIDEBAR_OPEN":
+      return { ...state, sidebarOpen: action.payload };
+    default:
+      return state;
+  }
+}
+
+const StoreContext = createContext();
+
+export function AppStoreProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  return (
+    <StoreContext.Provider value={{ state, dispatch }}>
+      {children}
+    </StoreContext.Provider>
+  );
+}
+
+export default function useAppStore() {
+  const context = useContext(StoreContext);
+  if (!context) {
+    throw new Error("useAppStore must be used within AppStoreProvider");
+  }
+  const { state, dispatch } = context;
+  return {
+    ...state,
+    setQuery: (payload) => dispatch({ type: "SET_QUERY", payload }),
+    setFilterState: (payload) => dispatch({ type: "SET_FILTER_STATE", payload }),
+    setFilterProjectStatus: (payload) => dispatch({ type: "SET_FILTER_PROJECT_STATUS", payload }),
+    setFilterAssignee: (payload) => dispatch({ type: "SET_FILTER_ASSIGNEE", payload }),
+    setFilterTag: (payload) => dispatch({ type: "SET_FILTER_TAG", payload }),
+    setFilterMilestone: (payload) => dispatch({ type: "SET_FILTER_MILESTONE", payload }),
+    setFilterIssueType: (payload) => dispatch({ type: "SET_FILTER_ISSUE_TYPE", payload }),
+    setRange: (payload) => dispatch({ type: "SET_RANGE", payload }),
+    setBurnRange: (payload) => dispatch({ type: "SET_BURN_RANGE", payload }),
+    setTheme: (payload) => dispatch({ type: "SET_THEME", payload }),
+    setDensity: (payload) => dispatch({ type: "SET_DENSITY", payload }),
+    setSidebarOpen: (payload) => dispatch({ type: "SET_SIDEBAR_OPEN", payload }),
+  };
+}


### PR DESCRIPTION
## Summary
- introduce a React context store to centralize filters, theme, and other UI state
- refactor core pages to consume global state instead of prop drilling
- wrap tests with the new AppStoreProvider

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b166e0cdac8328bd689d75ebb1789e