### PR TITLE
feat: expand issue card with full history

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -342,6 +342,7 @@ export default function App() {
                 tagOptions={tagOptions}
                 milestoneOptions={milestoneOptions}
                 issueTypeOptions={issueTypeOptions}
+                token={token}
               />
             } />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/AllIssues.jsx
+++ b/src/components/AllIssues.jsx
@@ -5,6 +5,7 @@ import { Input } from "./ui/input";
 import { Download, Search } from "lucide-react";
 import IssueCard, { ExpandedIssueCard } from "./IssueCard";
 import useAppStore from "../store";
+import { fetchIssueWithTimeline } from "../api/github";
 
 function issuesToCSV(issues) {
   const headers = ["Number", "Title", "URL", "State", "Repository", "ProjectStatus", "CreatedAt", "ClosedAt"];
@@ -38,7 +39,8 @@ export default function AllIssues({
   assigneeOptions,
   issueTypeOptions,
   tagOptions,
-  milestoneOptions
+  milestoneOptions,
+  token,
 }) {
   const {
     query,
@@ -92,9 +94,16 @@ export default function AllIssues({
     [filteredAllIssues, visibleCount]
   );
 
-  const handleIssueClick = (issue) => {
+  const handleIssueClick = async (issue) => {
     setClickedIssue(issue.id);
-    setClickedIssueData(issue);
+    try {
+      const [owner, repo] = (issue.repository?.nameWithOwner || "").split("/");
+      const full = await fetchIssueWithTimeline(token, owner, repo, issue.number);
+      setClickedIssueData(full || issue);
+    } catch (e) {
+      console.error(e);
+      setClickedIssueData(issue);
+    }
   };
 
   const handleClosePopup = () => {

--- a/src/components/IssueCard.jsx
+++ b/src/components/IssueCard.jsx
@@ -53,6 +53,45 @@ export function ExpandedIssueCard({ issue }) {
   const processedBody = convertImgTagsToMarkdown(issue.body || "");
   const displayBody =
     processedBody.length > 500 ? `${processedBody.substring(0, 500)}...` : processedBody;
+
+  const renderTimelineItem = (item, idx) => {
+    const time = item.createdAt ? new Date(item.createdAt).toLocaleString() : "";
+    switch (item.__typename) {
+      case "IssueComment":
+        return (
+          <li key={idx}>
+            <div className="text-gray-700"><span className="font-medium">{item.author?.login}</span> commented {time}</div>
+            {item.body && <div className="ml-4 text-gray-600">{item.body.length > 200 ? item.body.substring(0,200) + "..." : item.body}</div>}
+          </li>
+        );
+      case "ClosedEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> closed this issue {time}</li>
+        );
+      case "ReopenedEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> reopened this issue {time}</li>
+        );
+      case "LabeledEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> added label {item.label?.name} {time}</li>
+        );
+      case "UnlabeledEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> removed label {item.label?.name} {time}</li>
+        );
+      case "AssignedEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> assigned {item.assignee?.login} {time}</li>
+        );
+      case "UnassignedEvent":
+        return (
+          <li key={idx} className="text-gray-700"><span className="font-medium">{item.actor?.login}</span> unassigned {item.assignee?.login} {time}</li>
+        );
+      default:
+        return null;
+    }
+  };
   
   return (
     <div className="bg-white border rounded-lg shadow-xl p-5 max-w-md">
@@ -195,6 +234,14 @@ export function ExpandedIssueCard({ issue }) {
               {displayBody}
             </ReactMarkdown>
           </div>
+        </div>
+      )}
+      {issue.timelineItems && issue.timelineItems.length > 0 && (
+        <div className="border-t pt-3 mt-3">
+          <div className="text-sm text-gray-500 font-medium mb-2">History:</div>
+          <ul className="space-y-2 text-sm max-h-40 overflow-y-auto">
+            {issue.timelineItems.map((t, i) => renderTimelineItem(t, i))}
+          </ul>
         </div>
       )}
     </div>

--- a/src/components/SprintBoard.jsx
+++ b/src/components/SprintBoard.jsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/button";
 import { Download, Maximize2, Minimize2 } from "lucide-react";
 import IssueCard, { ExpandedIssueCard } from "./IssueCard";
 import jsPDF from "jspdf";
+import { fetchIssueWithTimeline } from "../api/github";
 
 function formatDateForHeader(date) {
   const d = new Date(date);
@@ -341,15 +342,23 @@ async function downloadReleaseNotes(sp, orgName) {
   doc.save(`${sp.title}-release-notes.pdf`);
 }
 
-export default function SprintBoard({ sprint, isFullScreen, toggleFullScreen, handleDrop, orgName }) {
+
+export default function SprintBoard({ sprint, isFullScreen, toggleFullScreen, handleDrop, orgName, token }) {
   const [clickedIssue, setClickedIssue] = useState(null);
   const [clickedIssueData, setClickedIssueData] = useState(null);
 
   if (!sprint) return null;
 
-  const handleIssueClick = (issue) => {
+  const handleIssueClick = async (issue) => {
     setClickedIssue(issue.id);
-    setClickedIssueData(issue);
+    try {
+      const [owner, repo] = (issue.repository?.nameWithOwner || "").split("/");
+      const full = await fetchIssueWithTimeline(token, owner, repo, issue.number);
+      setClickedIssueData(full || issue);
+    } catch (e) {
+      console.error(e);
+      setClickedIssueData(issue);
+    }
   };
 
   const handleClosePopup = () => {

--- a/src/components/Sprints.jsx
+++ b/src/components/Sprints.jsx
@@ -172,6 +172,7 @@ export default function Sprints({ allIssues, orgMeta, projects, token }) {
           toggleFullScreen={toggleFullScreen}
           handleDrop={handleDrop}
           orgName={orgMeta?.name}
+          token={token}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- fetch full timeline for an issue
- show history in expanded issue card popup
- load full issue details when clicking from lists

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68c6adc0b4048328b087b077ad2f21af